### PR TITLE
* 非同期でのble送信が非常に不安定なため同期処理に変更

### DIFF
--- a/newtmgr/bll/bll_xport_linux.go
+++ b/newtmgr/bll/bll_xport_linux.go
@@ -38,10 +38,13 @@ func BllXportSetConnParams(dev ble.Device, ownAddrType bledefs.BleAddrType) erro
 		LEScanWindow:          0x0010, // 0x0004 - 0x4000; N * 0.625 msec
 		InitiatorFilterPolicy: 0x00,   // White list is not used
 		OwnAddressType:        uint8(ownAddrType),
-		ConnIntervalMin:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
-		ConnIntervalMax:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
+//		ConnIntervalMin:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
+//		ConnIntervalMax:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
+		ConnIntervalMin:       0x000a,
+		ConnIntervalMax:       0x0010,
 		ConnLatency:           0x0000, // 0x0000 - 0x01F3; N * 1.25 msec
-		SupervisionTimeout:    0x0048, // 0x000A - 0x0C80; N * 10 msec
+//		SupervisionTimeout:    0x0048, // 0x000A - 0x0C80; N * 10 msec
+		SupervisionTimeout:    0x0190,
 		MinimumCELength:       0x0000, // 0x0000 - 0xFFFF; N * 0.625 msec
 		MaximumCELength:       0x0000, // 0x0000 - 0xFFFF; N * 0.625 msec
 

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -360,11 +360,15 @@ func (c *ImageUploadCmd) Run(s sesn.Sesn) (Result, error) {
 
 		// Use up a chunk in window
 		t.WCount += 1
-		err = txReqAsync(s, r.Msg(), &c.CmdBase, rspc, errc)
+//		err = txReqAsync(s, r.Msg(), &c.CmdBase, rspc, errc)
+		rsp, err := txReq(s, r.Msg(), &c.CmdBase)
 		if err != nil {
+			errc <- err
 			log.Debugf("err txReqAsync %v", err)
 			t.Mutex.Unlock()
 			break
+		}else{
+			respc <- rsp
 		}
 		// Mark the expected offset in successful tx of this chunk. i.e off + len
 		t.UpdateTracker(int(r.Off)+len(r.Data), IMAGE_UPLOAD_STATUS_EXPECTED)


### PR DESCRIPTION
#### 問題点

masterのままmcumgrを動作させると非常に不安定であった。
* BLE通信での受信時にオフセットエラー頻発
* エラーが発生しても正常に終了しない
* エラーが発生しても正常に終了しないため、プロセスを強制終了するしか手立てがない
* disconnectされてもリトライしない

#### 解決方法

実装を見ると、BLE通信処理を非同期で組んでいるが(nmxact/xact/image.go)、  
同期処理へと変更した

#### 確認項目

主要で使用するコマンドを確認

* [x] image list
* [x] image erase
* [x] image upload
* [x] image test
* [x] image confirm
* [x] reset

エラーケースの動作
* [x] disconnectが発生した際、リトライを行う(mcumgr自体のリカバリ処理)
* [x] リカバリできないdisconnectが発生した際(拡張基盤のリセットなど)、エラーとして終了する
* [x] エラー終了した際、再度実行で正常に動作する

